### PR TITLE
test(hook): Modify package name resolution to fit.

### DIFF
--- a/test/hook.template.raw.test.js
+++ b/test/hook.template.raw.test.js
@@ -5,14 +5,16 @@ describe('hook.template.raw', function describeHookTemplateRaw() {
   describe('when ghooks is installed', () => {
 
     beforeEach(() => {
+      const path = require('path')
+      const ghooksEntryPoint = path.resolve(__dirname, '..', '{{node_modules_path}}', 'ghooks')
       this.ghooks = sinon.stub()
-      proxyquire('../lib/hook.template.raw', {ghooks: this.ghooks})
+      proxyquire('../lib/hook.template.raw', {[ghooksEntryPoint]: this.ghooks})
     })
 
     it('delegates the hook execution to ghooks', () => {
       const dirname = process.cwd() + '/lib'
       const filename = dirname + '/hook.template.raw'
-      expect(this.ghooks).to.have.been.calledWith(dirname, filename)
+      expect(this.ghooks).to.have.been.calledWith('{{node_modules_path}}', filename)
     })
 
   })
@@ -47,7 +49,7 @@ describe('hook.template.raw', function describeHookTemplateRaw() {
     it('delegates the hook execution to ghooks', () => {
       const dirname = process.cwd() + '/lib'
       const filename = dirname + '/hook.template.raw'
-      expect(this.ghooks).to.have.been.calledWith(dirname, filename)
+      expect(this.ghooks).to.have.been.calledWith('{{node_modules_path}}', filename)
     })
 
   })


### PR DESCRIPTION
Altered the exisiting tests that failed due to the newly introduced prerendered resolution of `ghooks`' package location.
(I hope that description makes any sense)
